### PR TITLE
Add Sysdig workaround for GKE node MAC address conflicts

### DIFF
--- a/sysdig-daemon.yml
+++ b/sysdig-daemon.yml
@@ -42,7 +42,9 @@ spec:
           valueFrom:
               secretKeyRef:
                   name: sysdig
-                  key: access-key
+                  key: access_key
+        - name: ADDITIONAL_CONF                                  
+          value: "machine_id_prefix: retraced-"
         volumeMounts:
         - mountPath: /host/var/run/docker.sock
           name: docker-sock


### PR DESCRIPTION
By default, sysdig makes sure that an agent's eth0 MAC address
is different from that of any other running agent.

Adding a unique prefix seems to be enough to convince sysdig that
we're not running multiple agents on the same node:
https://support.sysdigcloud.com/hc/en-us/articles/115000219643